### PR TITLE
fix: InGameUI 시간 표시 로직 개선

### DIFF
--- a/Source/TFD/GameMode/TFDGameMode.cpp
+++ b/Source/TFD/GameMode/TFDGameMode.cpp
@@ -631,13 +631,6 @@ void ATFDGameMode::Tick(float DeltaTime)
 
 	GetGameState()->GameRemainServerTime -= DeltaTime;
 
-	// 호스트용 직접 브로드캐스트
-	if (GetGameState()->HasAuthority())
-	{
-		GetGameState()->OnGameTimeChanged.Broadcast(GetGameState()->GameRemainServerTime);
-	}
-
-
 	// 시간이 종료될 시 게임 종료 로직
 	if (GetGameState()->GameRemainServerTime < 0)
 	{

--- a/Source/TFD/GameState/TFDGameState.cpp
+++ b/Source/TFD/GameState/TFDGameState.cpp
@@ -38,7 +38,6 @@ void ATFDGameState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-	DOREPLIFETIME(ATFDGameState, GameRemainServerTime);
 	DOREPLIFETIME(ATFDGameState, ThiefTotalScore);
 	DOREPLIFETIME(ATFDGameState, PolicePlayerStateArray);
 	DOREPLIFETIME(ATFDGameState, ThiefPlayerStateArray);
@@ -123,11 +122,6 @@ void ATFDGameState::OnRep_ThiefScore()
 		// 클라에서도 점수 변경 이벤트 발행 (UI 갱신 가능)
 		OnThiefScoreChanged.Broadcast(ThiefTotalScore);
 	}
-}
-
-void ATFDGameState::OnRep_GameRemainTime()
-{
-	OnGameTimeChanged.Broadcast(GameRemainServerTime);
 }
 
 void ATFDGameState::OnRep_PolicePlayerStateArray()

--- a/Source/TFD/GameState/TFDGameState.h
+++ b/Source/TFD/GameState/TFDGameState.h
@@ -13,7 +13,6 @@
 // 도둑 전체 점수 변경 이벤트 (UI나 GameMode에서 구독 가능)
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnThiefScoreChanged, int32, NewScore);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnThievesChanged);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGameTimeChanged, float, RemainingTimeSec);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMachInProgress);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnMatchWaitingPostMatch, FGameplayTag, WinTeamTag, EGameCompleteType, CompleteType);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnThiefArrayChanged, const TArray<TWeakObjectPtr<ATFDPlayerState>>&, ThiefArray);
@@ -56,9 +55,6 @@ protected:
 
 	UFUNCTION()
 	void OnRep_ThiefScore();
-
-	UFUNCTION()
-	void OnRep_GameRemainTime();
 
 	UFUNCTION()
 	void OnRep_PolicePlayerStateArray();
@@ -105,9 +101,6 @@ public:
 	FOnThievesChanged OnThievesChanged;
 
 	UPROPERTY(BlueprintAssignable, Category = "Events")
-	FOnGameTimeChanged OnGameTimeChanged;
-
-	UPROPERTY(BlueprintAssignable, Category = "Events")
 	FOnMachInProgress OnMachInProgress;
 
 	UPROPERTY(BlueprintAssignable, Category = "Events")
@@ -126,7 +119,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FOnPoliceItemArrayChanged OnPoliceItemArrayChanged;
 
-	UPROPERTY(ReplicatedUsing = OnRep_GameRemainTime, BlueprintReadOnly, Category = "Time")
+	UPROPERTY(BlueprintReadOnly, Category = "Time")
 	float GameRemainServerTime = 5.f;
 
 protected:

--- a/Source/TFD/UI/InGame/PlayingWidget.cpp
+++ b/Source/TFD/UI/InGame/PlayingWidget.cpp
@@ -12,39 +12,42 @@ void UPlayingWidget::NativeConstruct()
     Super::NativeConstruct();
 
     UE_LOG(LogTemp, Log, TEXT("[UPlayingWidget] NativeConstruct called."));
+    APlayerController* PC = GetOwningPlayer();
+    if (!PC) return;
 
-    if (APlayerController* PC = GetOwningPlayer())
-    {
-        UpdateTeamName();
-
-
-        CachedGameState = PC->GetWorld()->GetGameState<ATFDGameState>();
-        if (CachedGameState)
-        {
-            UE_LOG(LogTemp, Log, TEXT("[UPlayingWidget] CachedGameState found: %s"), *CachedGameState->GetName());
-
-            // 델리게이트 바인딩
-            CachedGameState->OnThiefScoreChanged.AddDynamic(this, &UPlayingWidget::UpdateThiefScore);
-            CachedGameState->OnThievesChanged.AddDynamic(this, &UPlayingWidget::UpdateThiefCount);
-            CachedGameState->OnGameTimeChanged.AddDynamic(this, &UPlayingWidget::UpdateRemainingTime);
-
-            // HUD 초기화
-            UpdateFromGameState();
-        }
-    }
-}
-
-
-void UPlayingWidget::UpdateFromGameState()
-{
-
-    if (!CachedGameState)
-    {
-        UE_LOG(LogTemp, Warning, TEXT("[UPlayingWidget] CachedGameState is null, cannot update HUD."));
-        return;
-    }
+    CachedGameState = PC->GetWorld()->GetGameState<ATFDGameState>();
+    if (!CachedGameState) return;
+    
+    UE_LOG(LogTemp, Log, TEXT("[UPlayingWidget] CachedGameState found: %s"), *CachedGameState->GetName());
+    // 델리게이트 바인딩
+    CachedGameState->OnThiefScoreChanged.AddDynamic(this, &UPlayingWidget::UpdateThiefScore);
+    CachedGameState->OnThievesChanged.AddDynamic(this, &UPlayingWidget::UpdateThiefCount);
+    StartGameSec = CachedGameState->GetServerWorldTimeSeconds();
+    TotalGameSec = CachedGameState->GetRuleData()->PlayTimeSec;
+    
     UpdateThiefCount();
     UpdateThiefScore(0);
+    UpdateRemainingTime();
+    UpdateTeamName();
+    
+    GetWorld()->GetTimerManager().SetTimer(
+        RemainingTimeHandle,
+        this,
+        &UPlayingWidget::UpdateRemainingTime,
+        1.0f,
+        true
+    );
+    
+}
+
+void UPlayingWidget::NativeDestruct()
+{
+    Super::NativeDestruct();
+
+    if (GetWorld())
+    {
+        GetWorld()->GetTimerManager().ClearTimer(RemainingTimeHandle);
+    }
 }
 
 void UPlayingWidget::UpdateThiefScore(int32 NewScore)
@@ -58,58 +61,56 @@ void UPlayingWidget::UpdateThiefScore(int32 NewScore)
 
 void UPlayingWidget::UpdateThiefCount()
 {
-    if (!CachedGameState)
-    {
-        UE_LOG(LogTemp, Warning, TEXT("[UPlayingWidget] UpdateThiefCount 호출됨, 하지만 CachedGameState 없음"));
-        return;
-    }
+    if (!CachedGameState) return;
 
     int32 RemainingThieves = CachedGameState->ThiefPlayerStateArray.Num();
     int32 CaughtThieves = CachedGameState->CaughtThiefPlayerStateArray.Num();
 
-    if (ThiefCountText)
-        ThiefCountText->SetText(FText::FromString(FString::Printf(TEXT("총 도둑 수: %d / 잡힌 도둑 수: %d"), RemainingThieves, CaughtThieves)));
+    if (!ThiefCountText) return;
+    
+    ThiefCountText->SetText(FText::FromString(FString::Printf(TEXT("총 도둑 수: %d / 잡힌 도둑 수: %d"), RemainingThieves, CaughtThieves)));
 }
 
-void UPlayingWidget::UpdateRemainingTime(float RemainingTimeSec)
+void UPlayingWidget::UpdateRemainingTime()
 {
-    int32 Minutes = FMath::FloorToInt(RemainingTimeSec / 60.f);
-    int32 Seconds = FMath::FloorToInt(RemainingTimeSec) % 60;
 
-    if (RemainingTimeText)
-    {
-        RemainingTimeText->SetText(FText::FromString(FString::Printf(TEXT("%02d:%02d"), Minutes, Seconds)));
-    }
+
+    float RemainGameSec = TotalGameSec - (CachedGameState->GetServerWorldTimeSeconds() - StartGameSec);
+
+    int32 RemainMinutes = FMath::FloorToInt(RemainGameSec / 60.f);
+    int32 RemainSeconds = FMath::FloorToInt(RemainGameSec) % 60;
+
+    if (!RemainingTimeText) return;
+    
+    RemainingTimeText->SetText(FText::FromString(FString::Printf(TEXT("%02d:%02d"), RemainMinutes, RemainSeconds)));
 }
 
 void UPlayingWidget::UpdateTeamName()
 {
-    if (ATFDPlayerState* PS = GetOwningPlayer()->GetPlayerState<ATFDPlayerState>())
-    {
-        FGameplayTag TeamTag = PS->GetTeamTag();
-
-        // TeamTag가 None이면 다음 Tick에 재시도
-        if (!TeamTag.IsValid())
-        {
-            GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
-                {
-                    UpdateTeamName();
-                });
-            return;
-        }
-
-        // 팀 이름 바로 업데이트
-        if (TeamNameText)
-        {
-            TeamNameText->SetText(FText::FromString(FString::Printf(TEXT("팀: %s"), *TeamTag.ToString())));
-        }
-    }
-    else
+    ATFDPlayerState* PS = GetOwningPlayer()->GetPlayerState<ATFDPlayerState>();
+    if (!PS)
     {
         // PlayerState가 아직 없으면 다음 Tick에 재시도
         GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
             {
                 UpdateTeamName();
             });
+        return;
     }
+
+    FGameplayTag TeamTag = PS->GetTeamTag();
+
+    if (!TeamTag.IsValid())
+    {
+        GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
+            {
+                UpdateTeamName();
+            });
+        return;
+    }
+
+        // 팀 이름 바로 업데이트
+    if (!TeamNameText) return;
+    
+    TeamNameText->SetText(FText::FromString(FString::Printf(TEXT("팀: %s"), *TeamTag.ToString())));
 }

--- a/Source/TFD/UI/InGame/PlayingWidget.h
+++ b/Source/TFD/UI/InGame/PlayingWidget.h
@@ -20,10 +20,7 @@ class TFD_API UPlayingWidget : public UUserWidget
 
 public:
     virtual void NativeConstruct() override;
-
-    /** HUD 업데이트 */
-    UFUNCTION()
-    void UpdateFromGameState();
+    virtual void NativeDestruct() override;
 
     UFUNCTION(BlueprintCallable)
     void UpdateThiefScore(int32 NewScore);
@@ -32,12 +29,17 @@ public:
     void UpdateThiefCount();
 
     UFUNCTION(BlueprintCallable)
-    void UpdateRemainingTime(float RemainingTimeSec);
+    void UpdateRemainingTime();
 
     UFUNCTION(BlueprintCallable)
     void UpdateTeamName();
 
 protected:
+    float StartGameSec;
+    float TotalGameSec;
+
+    FTimerHandle RemainingTimeHandle;
+
     UPROPERTY(meta = (BindWidget))
     UTextBlock* RemainingTimeText;
 


### PR DESCRIPTION
## 현재 로직
- GameMode의 Tick 함수에서 GameRemainServerTime계속 감소
- 값이 변할 때마다 OnGameTimeChanged.Broadcast  호출 → 클라 HUD 갱신.
- 서버가 틱마다 브로드캐스트 → 클라가 이벤트로 HUD 업데이트.


## 변경 로직
- 위젯에서 게임 시작 시 게임 스테이트에서 서버 시간 및 총 게임 시간을 불러옴.
- 시간 업데이트 로직
  - 현재 서버 시간 - 시작 시간 = 진행된 시간
  - 남은 시간 = 총 게임 시간 - 진행된 시간
  - 위 로직으로 1초마다 텍스트 업데이트