### PR TITLE
fix: 클라이언트 투사체 시각화 문제 해결 (연속 발사 시 2번째 이후 투사체 미표시)

### DIFF
--- a/Source/TFD/GameAbilitySystem/Task/TFDAbilityTask_FireProjectile.cpp
+++ b/Source/TFD/GameAbilitySystem/Task/TFDAbilityTask_FireProjectile.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 
 #include "GameAbilitySystem/Task/TFDAbilityTask_FireProjectile.h"
@@ -50,6 +50,10 @@ void UTFDAbilityTask_FireProjectile::Activate()
 	if (Ability->GetCurrentActorInfo()->IsNetAuthority())
 	{
 		ShootProjectile(); // 실제 스폰 
+	}
+	else
+	{// 클라이언트에서는 시각적 효과만 생성
+		SpawnCosmeticProjectile();
 	}
 }
 
@@ -194,4 +198,53 @@ bool UTFDAbilityTask_FireProjectile::CalcSpawnTransform(ATFDCharacterBase* Chara
 	result = true;
 	
 	return result;
+}
+
+void UTFDAbilityTask_FireProjectile::SpawnCosmeticProjectile()
+{
+	AActor* AvatarActor = Ability->GetCurrentActorInfo()->AvatarActor.Get();
+	if (!AvatarActor)
+	{
+		EndTask();
+		return;
+	}
+
+	ATFDCharacterBase* Character = Cast<ATFDCharacterBase>(AvatarActor);
+	if (!Character || !CalcSpawnTransform(Character, SpawnWorldTransform))
+	{
+		EndTask();
+		return;
+	}
+
+	ATFDBaseProjectile* CosmeticProjectile = Cast<ATFDBaseProjectile>(
+		UGameplayStatics::BeginDeferredActorSpawnFromClass(
+			GetWorld(),
+			TaskParams.ProjectileClass,
+			SpawnWorldTransform,
+			ESpawnActorCollisionHandlingMethod::AlwaysSpawn,
+			AvatarActor
+		)
+	);
+
+	if (CosmeticProjectile)
+	{
+		// Cosmetic 플래그 설정
+		CosmeticProjectile->bIsCosmeticOnly = true;
+
+		FTFDBaseObjectParam CosmeticParam = TaskParams.BaseObjectParam;
+		CosmeticParam.bMoveFlag = true;
+
+		CosmeticProjectile->SetBaseObjectParam(CosmeticParam);
+		CosmeticProjectile->SetInstigator(Cast<APawn>(AvatarActor));
+		CosmeticProjectile->InitialLifeSpan = TaskParams.ProjectileLifeSpan;
+
+		// 충돌은 활성화 상태로 유지 (DisableCollision 호출 안 함)
+		// 충돌 감지는 하되, OnOverlapBegin에서 bIsCosmeticOnly로 구분
+
+		UGameplayStatics::FinishSpawningActor(CosmeticProjectile, SpawnWorldTransform);
+
+		UE_LOG(LogTemp, Warning, TEXT("[UTFDAbilityTask_FireProjectile][SpawnCosmeticProjectile] Cosmetic Projectile Spawned with collision enabled"));
+	}
+
+	EndTask();
 }

--- a/Source/TFD/GameAbilitySystem/Task/TFDAbilityTask_FireProjectile.h
+++ b/Source/TFD/GameAbilitySystem/Task/TFDAbilityTask_FireProjectile.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -72,6 +72,9 @@ private:
 	void ShootProjectile();
 	bool CheckProjectile(AActor& pActor, UAbilitySystemComponent& SourceASC);
 	bool CalcSpawnTransform(ATFDCharacterBase* Character, FTransform& OutSpawnTransform);
+
+	// 클라이언트 전용 시각 효과 투사체 생성
+	void SpawnCosmeticProjectile();
 
 private:
 	//발사체 최종 트랜스폼

--- a/Source/TFD/Object/TFDBaseObject.cpp
+++ b/Source/TFD/Object/TFDBaseObject.cpp
@@ -30,6 +30,18 @@ void ATFDBaseObject::OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor*
                                     UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep,
                                     const FHitResult& SweepResult)
 {
+	// Cosmetic 전용이면 시각 효과만 처리하고 파괴
+	if (bIsCosmeticOnly)
+	{
+		ATFDCharacterBase* Player = Cast<ATFDCharacterBase>(OtherActor);
+		if (Player)
+		{// 충돌 감지 시 시각적으로만 사라짐
+			UE_LOG(LogTemp, Log, TEXT("[ATFDBaseObject][OnOverlapBegin] Cosmetic Projectile Hit detected, destroying visual"));
+			Destroy();
+		}
+		return;
+	}
+
 	if (!CollisionEffect)
 		return;
 
@@ -78,6 +90,16 @@ void ATFDBaseObject::DefaultCreater()
 	MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 }
 
+//void ATFDBaseObject::DisableCollision()
+//{
+//	if (CollisionComp)
+//	{
+//		CollisionComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+//
+//		// 오버랩 이벤트도 바인딩 해제
+//		CollisionComp->OnComponentBeginOverlap.RemoveDynamic(this, &ATFDBaseObject::OnOverlapBegin);
+//	}
+//}
 
 void ATFDBaseObject::SetAllowedTeamTag()
 {

--- a/Source/TFD/Object/TFDBaseObject.h
+++ b/Source/TFD/Object/TFDBaseObject.h
@@ -65,6 +65,10 @@ public:
 
 	const FGameplayTagContainer& GetAllowedTeamTag() const { return AllowedTeamTag; }
 
+public:
+	UPROPERTY()
+	bool bIsCosmeticOnly = false;
+
 private:
 	void SetAllowedTeamTag();
 	//bool HasAllowedTeamTag(UAbilitySystemComponent* ASC) const;


### PR DESCRIPTION
## 문제 상황
클라이언트에서 투사체 스킬 연속 사용 시 첫 번째만 시각적으로 표시되고, 
이후 발사체는 보이지 않는 문제 발생
- 서버에서만 투사체 생성 후 리플리케이션에 의존
- GAS Ability Task 실행 흐름 및 리플리케이션 타이밍 이슈

## 해결 방법
클라이언트가 로컬에서 시각 효과 전용 투사체를 직접 생성하도록 변경

### 구현 세부사항
- **서버**: 충돌 감지 및 효과 적용을 처리하는 게임플레이 투사체 생성
- **클라이언트**: `bIsCosmeticOnly` 플래그가 설정된 시각 효과 전용 투사체 생성
- 투사체 리플리케이션 불필요 → 네트워크 부하 감소
- 네트워크 지연 없이 즉각적인 시각 피드백 제공

## 변경 사항
**1. TFDBaseObject**: Cosmetic 투사체 구분 로직 추가
- `bIsCosmeticOnly` 플래그 추가
- `OnOverlapBegin()`에서 Cosmetic 투사체는 효과 없이 파괴만 처리

**2. TFDAbilityTask_FireProjectile**: 클라이언트 로컬 투사체 생성 구현
- `SpawnCosmeticProjectile()` 함수 추가
- `Activate()`에서 클라이언트/서버 분기 처리

## 커밋 내역
- feat: 클라이언트 시각 효과 전용 투사체 지원 추가
- feat: AbilityTask에 클라이언트 로컬 Cosmetic 투사체 생성 구현