### PR TITLE
fix: 로비 UI 로직 Timer Clear

### DIFF
--- a/Source/TFD/UI/InGame/SkillSlotItem.cpp
+++ b/Source/TFD/UI/InGame/SkillSlotItem.cpp
@@ -43,19 +43,6 @@ void USkillSlotItem::UpdateSlot(const FTFDSkillSlot& InSlot, int32 SlotIndex)
 
         if(IconType != EUIIconType::None)
         {
-            /*
-            // GameInstance에 Sprite 요청
-            GI->RequestUIIcon(IconType, [this](const TObjectPtr<UPaperSprite>& Sprite)
-                {
-                    if (Sprite)
-                    {
-                        const FVector2D& Size = SkillIcon->GetDesiredSize();
-                        FSlateBrush Brush = UUIResourceAsset::MakeBrushFromSprite(Sprite, Size.X, Size.Y);
-                        SkillIcon->SetBrush(Brush);
-                        SkillIcon->SetOpacity(1.0f);
-                    }
-                });
-            */
             const TSoftObjectPtr<UPaperSprite>* Found = GI->LoadedUIResource->IconMap.Find(IconType);
             if (!Found) return;
 

--- a/Source/TFD/UI/OutGame/UW_Lobby.cpp
+++ b/Source/TFD/UI/OutGame/UW_Lobby.cpp
@@ -179,7 +179,7 @@ void UUW_Lobby::NativeDestruct()
 		}
 	}
 
-
+	GetWorld()->GetTimerManager().ClearTimer(RefreshTimerHandle);
 
 }
 


### PR DESCRIPTION
1. 로비에서 인게임으로 넘어가도 타이머를 중지하지 않아서 HandlePlayerListChanged()를 0.5초마다 호출하는 문제 작업
2. SkillSlotItem 필요없는 주석 제거